### PR TITLE
Fix cuda target on multi-gpu host

### DIFF
--- a/FastGeodis/fastgeodis.cpp
+++ b/FastGeodis/fastgeodis.cpp
@@ -29,6 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <iostream>
 #include <future>
 #include <vector>
@@ -75,6 +76,12 @@ torch::Tensor generalised_geodesic2d(const torch::Tensor &image, const torch::Te
                 "cuda.is_available() returned false, please check if the library was compiled successfully with CUDA support");
         }
         check_cuda(mask);
+
+        int device = image.get_device();
+        #if VERBOSE
+            std::cout << "Running with CUDA Device: " << device << std::endl;
+        #endif
+        c10::cuda::CUDAGuard device_guard(device);
 
         return generalised_geodesic2d_cuda(image, mask, v, l_grad, l_eucl, iterations);
 
@@ -131,6 +138,11 @@ torch::Tensor generalised_geodesic3d(const torch::Tensor &image, const torch::Te
                 "cuda.is_available() returned false, please check if the library was compiled successfully with CUDA support");
         }
         check_cuda(mask);
+        int device = image.get_device();
+        #if VERBOSE
+            std::cout << "Running with CUDA Device: " << device << std::endl;
+        #endif
+        c10::cuda::CUDAGuard device_guard(device);
         
         return generalised_geodesic3d_cuda(image, mask, spacing, v, l_grad, l_eucl, iterations);
 


### PR DESCRIPTION
Attempting to fix cuda device error on multi-gpu device, see #43  for more details.

The solution is to utilize CUDA Guard [link](https://discuss.pytorch.org/t/how-to-set-default-cuda-device-in-libtorch/105120/2).

Tested locally on 2 GPU machine