### PR TITLE
Fix same padding compatibility with older pytorch versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ dep_dir = os.path.join(".", "dependency")
 
 setup(
     name="FastGeodis",
-    version="1.0.3",
+    version="1.0.4",
     description="Fast Implementation of Generalised Geodesic Distance Transform for CPU (OpenMP) and GPU (CUDA)",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Older pytorch versions do not support `same` padding. Hence this PR fixes this backward compatiblity issue by implementing `same` padding manually and supporting older pytorch versions that did not have this functionality. 

Fixes #51 